### PR TITLE
Update installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A Python tool for collecting information when reporting bugs.
 ## Installation
 
 ```
-pip install git+https://github.com/zooba/reportabug
-pip install reportabug
+python -m pip install git+https://github.com/zooba/reportabug
+python -m pip install reportabug
 ```
 
 ## Usage


### PR DESCRIPTION
Someone once told me that it is preferred to do `python -m pip install ...`
Instead of just `pip install ...`.
This change does that.